### PR TITLE
Fix maven pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,15 @@
           </archive>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
           <archive>
             <manifest>
               <!-- full package name of class with the main you want to run -->
-              <mainClass>${mainClass}</mainClass>
+              <mainClass>edu.ucsb.cs56.w20.Hello</mainClass>
             </manifest>
           </archive>
         </configuration>


### PR DESCRIPTION
This PR makes a couple of changes:

* Configures maven-compiler-plugin to compile using Java 11
* Properly sets the main class of maven-jar-plugin so that `mvn package` works